### PR TITLE
Ensure SSH commands are safely quoted

### DIFF
--- a/src/claudecontrol/claude_helpers.py
+++ b/src/claudecontrol/claude_helpers.py
@@ -5,6 +5,7 @@ Makes common tasks extremely simple
 
 import json
 import time
+import shlex
 import pexpect
 from pathlib import Path
 from typing import Optional, Union, List, Dict, Any
@@ -198,7 +199,7 @@ def ssh_command(
     else:
         ssh_cmd += f" {host}"
         
-    ssh_cmd += f" {command}"
+    ssh_cmd += f" {shlex.quote(command)}"
     
     with Session(ssh_cmd, timeout=timeout, persist=False) as session:
         # Handle SSH prompts


### PR DESCRIPTION
## Summary
- Quote remote commands in `ssh_command` using `shlex.quote`
- Add unit test verifying spaces in SSH commands are properly quoted

## Testing
- `pytest -q` *(fails: multiple existing tests failing in repository)*
- `pytest tests/test_helpers.py::TestSSHCommand::test_quotes_command -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4ff24463c8321a8240b694c1cfabb