### PR TITLE
Handle errors in test_command helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,11 @@ with Session("database_cli") as session:
 from claudecontrol.claude_helpers import test_command, parallel_commands
 
 # Test if command works
-if test_command("npm test", expected_output="passing"):
+success, error = test_command("npm test", expected_output="passing")
+if success:
     print("Tests passed!")
+else:
+    print(f"Tests failed: {error}")
 
 # Run multiple commands in parallel
 results = parallel_commands([
@@ -274,8 +277,11 @@ match = session.wait_for_regex(r"\d+")       # Regex with match object
 ```python
 from claudecontrol.claude_helpers import test_command
 
-if test_command("npm test", ["✓", "passing"]):
+success, error = test_command("npm test", ["✓", "passing"])
+if success:
     print("All tests passed!")
+else:
+    print(f"Tests failed: {error}")
 ```
 
 ### Interactive Sessions

--- a/api_interfaces.md
+++ b/api_interfaces.md
@@ -193,12 +193,12 @@
 
 ## Helper Function Interfaces
 
-### `test_command(command: str, expected_output: Union[str, List[str]], timeout: int = 30, cwd: Optional[str] = None) -> bool`
+### `test_command(command: str, expected_output: Union[str, List[str]], timeout: int = 30, cwd: Optional[str] = None) -> Tuple[bool, Optional[str]]`
 **Purpose:** Test if a command produces expected output
 **Location:** `src/claudecontrol/claude_helpers.py`
 
-**Returns:** True if all expected outputs found, False otherwise
-**Error Handling:** Returns False on any exception
+**Returns:** Tuple of `(success, error_message)` where `error_message` is `None` when all expected outputs are found
+**Error Handling:** Returns `(False, str(e))` on any exception
 
 ### `interactive_command(command: str, interactions: List[Dict[str, str]], timeout: int = 30, cwd: Optional[str] = None) -> str`
 **Purpose:** Run command with scripted interactions

--- a/call_graph.md
+++ b/call_graph.md
@@ -336,7 +336,7 @@ graph LR
 
 ### Example 1: Interactive Command
 ```
-test_command("npm test", "passing")
+success, error = test_command("npm test", "passing")
   └── run("npm test", expect="passing")
       └── Session.__init__("npm test")
           └── pexpect.spawn("npm test")

--- a/src/claudecontrol/interactive_menu.py
+++ b/src/claudecontrol/interactive_menu.py
@@ -478,11 +478,12 @@ class InteractiveMenu:
         
         try:
             if expected:
-                result = test_command(command, expected, timeout=10)
-                if result:
+                success, error = test_command(command, expected, timeout=10)
+                if success:
                     print("✓ TEST PASSED - Found expected output")
                 else:
-                    print("✗ TEST FAILED - Expected output not found")
+                    message = error or "Expected output not found"
+                    print(f"✗ TEST FAILED - {message}")
             else:
                 from .core import run
                 output = run(command, timeout=10)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -20,31 +20,35 @@ class TestTestCommand:
     
     def test_simple_success(self):
         """Test command with expected output"""
-        result = test_command("echo 'hello world'", "hello")
-        assert result is True
+        success, error = test_command("echo 'hello world'", "hello")
+        assert success is True
+        assert error is None
     
     def test_simple_failure(self):
         """Test command without expected output"""
-        result = test_command("echo 'hello'", "goodbye")
-        assert result is False
+        success, _ = test_command("echo 'hello'", "goodbye")
+        assert success is False
     
     def test_multiple_patterns(self):
         """Test with multiple expected patterns"""
-        result = test_command("echo 'hello world'", ["hello", "world"])
-        assert result is True
-        
-        result = test_command("echo 'hello'", ["hello", "goodbye"])
-        assert result is False
+        success, error = test_command("echo 'hello world'", ["hello", "world"])
+        assert success is True
+        assert error is None
+
+        success, _ = test_command("echo 'hello'", ["hello", "goodbye"])
+        assert success is False
     
     def test_command_failure(self):
         """Test with failing command"""
-        result = test_command("false", "anything")
-        assert result is False
+        success, err = test_command("false", "anything")
+        assert success is False
+        assert err
     
     def test_with_timeout(self):
         """Test with timeout"""
-        result = test_command("sleep 10", "done", timeout=1)
-        assert result is False
+        success, err = test_command("sleep 10", "done", timeout=1)
+        assert success is False
+        assert err
 
 
 class TestInteractiveCommand:

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -42,9 +42,12 @@ class TestBasicFunctionality:
     def test_test_command(self):
         """Test the test_command helper"""
         # Test with true command
-        assert test_command("echo 'success'", "success") is True
+        success, error = test_command("echo 'success'", "success")
+        assert success is True
+        assert error is None
         # Test with false expectation
-        assert test_command("echo 'hello'", "goodbye") is False
+        success, _ = test_command("echo 'hello'", "goodbye")
+        assert success is False
     
     def test_session_lifecycle(self):
         """Test session creation and cleanup"""


### PR DESCRIPTION
## Summary
- capture error messages in `test_command` and return `(success, error)` tuple instead of only a boolean
- adapt interactive menu and tests for new tuple return style
- document updated `test_command` API and usage examples

## Testing
- `pytest tests/test_helpers.py::TestTestCommand -q`
- `pytest tests/test_simple.py::TestBasicFunctionality::test_test_command -q`
- `pytest -q` *(fails: TestSession::test_output_capture, TestSession::test_session_registry, TestRunScript::test_python_script, TestRunScript::test_bash_script, TestWatchProcess::test_watch_for_patterns, TestWatchProcess::test_watch_with_callback, TestParallelCommands::test_parallel_with_failures, TestCommandChain::test_conditional_execution)*

------
https://chatgpt.com/codex/tasks/task_e_68c50158dd288321910e5299c1951b5c