### PR TITLE
Align investigation APIs to canonical naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ ClaudeControl excels at exploring and understanding unknown CLI programs:
 ### Automatic Investigation
 
 ```python
-from claudecontrol.investigate import investigate_program
+from claudecontrol import investigate_program
 
 # Fully automated investigation
 report = investigate_program("unknown_app")

--- a/architecture_diagram.md
+++ b/architecture_diagram.md
@@ -167,7 +167,7 @@ graph TD
 - **Test Suites**: Startup, help system, invalid input, exit behavior, resources, concurrency, fuzzing
 
 ### Helper Functions
-- **claude_helpers.py**: High-level functions like test_command, probe_interface, investigate_program
+- **claude_helpers.py**: High-level functions like test_command, probe_interface, investigation_summary
 - **CommandChain**: Sequential command execution with conditions
 - **parallel_commands**: Run multiple commands concurrently
 - **watch_process**: Monitor processes for specific patterns

--- a/src/claudecontrol/__init__.py
+++ b/src/claudecontrol/__init__.py
@@ -33,13 +33,14 @@ from .claude_helpers import (
     interactive_command,
     run_script,
     status,
-    investigate_program,
+    investigation_summary,
     probe_interface,
     map_program_states,
     fuzz_program,
 )
 
 from .investigate import (
+    investigate_program,
     ProgramInvestigator,
     InvestigationReport,
 )
@@ -73,6 +74,7 @@ __all__ = [
     "run_script",
     "status",
     "investigate_program",
+    "investigation_summary",
     "probe_interface",
     "map_program_states",
     "fuzz_program",

--- a/src/claudecontrol/claude_helpers.py
+++ b/src/claudecontrol/claude_helpers.py
@@ -438,37 +438,37 @@ class CommandChain:
 
 
 # Investigation helpers
-def investigate_program(
+def investigation_summary(
     program: str,
     timeout: int = 10,
     safe_mode: bool = True,
     interactive: bool = False,
 ) -> Dict[str, Any]:
     """
-    Investigate an unknown program
-    
+    Generate a summarized view of an unknown program
+
     Args:
         program: Program to investigate
         timeout: Operation timeout
         safe_mode: Enable safety checks
         interactive: Use interactive learning mode
-        
+
     Returns:
         Investigation results dict
     """
     from .investigate import ProgramInvestigator
-    
+
     investigator = ProgramInvestigator(
         program=program,
         timeout=timeout,
         safe_mode=safe_mode,
     )
-    
+
     if interactive:
         report = investigator.learn_from_interaction()
     else:
         report = investigator.investigate()
-    
+
     return {
         "program": report.program,
         "prompts": report.prompts,

--- a/src/claudecontrol/interactive_menu.py
+++ b/src/claudecontrol/interactive_menu.py
@@ -12,7 +12,7 @@ from typing import Optional, Dict, Any, List
 from .core import control, list_sessions, get_session, cleanup_sessions
 from .claude_helpers import (
     test_command,
-    investigate_program,
+    investigation_summary,
     probe_interface,
     fuzz_program,
     status,
@@ -174,7 +174,7 @@ class InteractiveMenu:
         print("This may take a moment...\n")
         
         try:
-            result = investigate_program(
+            result = investigation_summary(
                 program=program,
                 timeout=10,
                 safe_mode=safe_mode,
@@ -777,7 +777,7 @@ Python API:
       calc.sendline("2+2")
 
 Investigation API:
-  from claudecontrol.investigate import investigate_program
+  from claudecontrol import investigate_program
   
   report = investigate_program("unknown_tool")
   print(report.summary())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,11 +11,11 @@ from pathlib import Path
 
 from claudecontrol import (
     Session, run, control, cleanup_sessions,
-    list_sessions, get_session
+    list_sessions, get_session, investigate_program
 )
 from claudecontrol.claude_helpers import (
     test_command, parallel_commands, CommandChain,
-    investigate_program, status
+    status
 )
 from claudecontrol.patterns import (
     extract_json, detect_prompt_pattern, classify_output

--- a/tests/test_investigate.py
+++ b/tests/test_investigate.py
@@ -7,6 +7,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+from claudecontrol import investigation_summary
 from claudecontrol.investigate import (
     ProgramInvestigator, InvestigationReport,
     ProgramState, investigate_program, load_investigation
@@ -225,9 +226,9 @@ class TestProgramInvestigator:
 
 class TestInvestigationHelpers:
     """Test investigation helper functions"""
-    
+
     def test_investigate_program_function(self):
-        """Test the investigate_program helper"""
+        """Test the investigate_program function"""
         report = investigate_program(
             "python --version",
             timeout=2,
@@ -258,6 +259,18 @@ class TestInvestigationHelpers:
         reports_dir = temp_dir / ".claude-control" / "investigations"
         assert reports_dir.exists()
         assert len(list(reports_dir.glob("*.json"))) > 0
+
+    def test_investigation_summary_helper(self):
+        """Test the investigation_summary convenience helper"""
+        summary = investigation_summary(
+            "echo 'summary'",
+            timeout=2,
+            safe_mode=True,
+        )
+
+        assert summary["program"] == "echo 'summary'"
+        assert "commands" in summary
+        assert "summary" in summary
 
 
 class TestInteractiveLearning:


### PR DESCRIPTION
## Summary
- rename the claude_helpers investigation helper to `investigation_summary` and keep `investigate_program` as the canonical report-returning API
- re-export `investigate_program` from the package root, update CLI/interactive menu usage, and refresh documentation to point at the new helper name
- adjust integration and investigation tests to import the canonical API and cover the new summary helper

## Testing
- `pytest` *(fails: numerous existing integration/unit expectations unrelated to rename)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f1f427388321abaff66752efe957