### PR TITLE
Handle ProcessError in watch_process

### DIFF
--- a/src/claudecontrol/claude_helpers.py
+++ b/src/claudecontrol/claude_helpers.py
@@ -12,7 +12,7 @@ from typing import Optional, Union, List, Dict, Any, Tuple
 
 from .core import control, run, get_session, list_sessions, Session
 from .patterns import wait_for_prompt, extract_json, COMMON_PROMPTS
-from .exceptions import SessionError, TimeoutError
+from .exceptions import SessionError, TimeoutError, ProcessError
 
 
 def test_command(
@@ -301,10 +301,12 @@ def watch_process(
                 index = session.expect(watch_for, timeout=5)
                 matched = watch_for[index]
                 matches.append(matched)
-                
+
                 if callback:
                     callback(session, matched)
-                    
+
+            except ProcessError:
+                break
             except TimeoutError:
                 # No match in this interval, keep watching
                 if not session.is_alive():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -141,18 +141,28 @@ class TestWatchProcess:
     def test_watch_with_callback(self):
         """Test watch with callback function"""
         callback_data = []
-        
+
         def callback(session, pattern):
             callback_data.append(pattern)
-        
+
         watch_process(
             "echo 'Error: test'",
             "Error:",
             callback=callback,
             timeout=2
         )
-        
+
         assert len(callback_data) > 0
+
+    def test_short_lived_command_returns_cleanly(self):
+        """Ensure short-lived commands don't raise errors"""
+        matches = watch_process(
+            "echo 'done'",
+            "nonexistent pattern",
+            timeout=2
+        )
+
+        assert matches == []
 
 
 class TestParallelCommands:


### PR DESCRIPTION
## Summary
- catch `ProcessError` when monitoring a process so `watch_process` exits cleanly when the child ends
- add a regression test to ensure short-lived processes return any collected matches without raising

## Testing
- pytest tests/test_helpers.py::TestWatchProcess

------
https://chatgpt.com/codex/tasks/task_e_68d165d3859c8321b1805cd93a323659