### PR TITLE
Raise ProcessError on non-zero exit and adjust helpers/tests

### DIFF
--- a/src/claudecontrol/claude_helpers.py
+++ b/src/claudecontrol/claude_helpers.py
@@ -416,15 +416,16 @@ class CommandChain:
         """Execute the command chain"""
         results = []
         last_success = True
+        had_failure = False
         
         for cmd_info in self.commands:
             # Check conditions
             if cmd_info["condition"] and not cmd_info["condition"](results):
                 continue
                 
-            if cmd_info["on_success"] and not last_success:
+            if cmd_info["on_success"] and (not last_success or had_failure):
                 continue
-                
+
             if cmd_info["on_failure"] and last_success:
                 continue
                 
@@ -454,9 +455,13 @@ class CommandChain:
                     "error": str(e),
                 }
                 last_success = False
-                
+                had_failure = True
+
             results.append(result)
-            
+
+            if not result["success"]:
+                had_failure = True
+
         return results
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -205,6 +205,15 @@ class TestRunFunction:
         output = run("python", expect=">>>", send="print('sent')\nexit()", timeout=5)
         assert "sent" in output or ">>>" in output  # May capture prompt or output
 
+    def test_run_failure_raises_process_error(self):
+        """Failing commands should raise ProcessError with output"""
+        with pytest.raises(ProcessError) as exc_info:
+            run("bash -c 'echo fail; exit 3'", timeout=5)
+
+        message = str(exc_info.value)
+        assert "exit status 3" in message
+        assert "fail" in message
+
 
 class TestControl:
     """Test the control() function"""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -193,10 +193,12 @@ class TestParallelCommands:
         ]
         
         results = parallel_commands(commands, timeout=5)
-        
+
         assert results["echo 'success'"]["success"] is True
         assert results["false"]["success"] is False
         assert results["this_does_not_exist"]["success"] is False
+        assert "false" in results["false"]["error"]
+        assert results["this_does_not_exist"]["error"]
 
 
 class TestSSHCommand:
@@ -266,6 +268,7 @@ class TestCommandChain:
         assert results[0]["success"] is True  # echo always
         assert results[1]["success"] is False  # false
         assert results[2]["success"] is True  # echo on_failure
+        assert "false" in results[1]["error"]
     
     def test_chain_with_condition(self):
         """Test chain with custom condition"""

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from claudecontrol import (
     Session, run, control, cleanup_sessions,
-    SessionError, TimeoutError
+    SessionError, TimeoutError, ProcessError
 )
 from claudecontrol.patterns import (
     extract_json, detect_prompt_pattern, is_error_output,
@@ -139,11 +139,9 @@ class TestQuickCommands:
         """Test true and false commands"""
         # true should succeed
         output = run("true")
-        # false will exit with non-zero but shouldn't crash
-        try:
-            output = run("false")
-        except:
-            pass  # Expected to fail
+        # false will exit with non-zero and should raise an error
+        with pytest.raises(ProcessError):
+            run("false")
     
     def test_echo_multiple(self):
         """Test multiple echo commands"""


### PR DESCRIPTION
## Summary
- check the spawned process exit and signal status in `core.run`, waiting on the child if needed, and raise `ProcessError` with the captured output when a command fails
- track whether a `CommandChain` has seen any failures so `on_success` steps are skipped after errors while `on_failure` hooks still run
- update unit tests to cover the new behaviour, including explicit assertions for failing commands in `run`, `parallel_commands`, `CommandChain`, and the simple command helpers

## Testing
- pytest tests/test_core.py::TestRunFunction::test_run_failure_raises_process_error tests/test_helpers.py::TestParallelCommands::test_parallel_with_failures tests/test_helpers.py::TestCommandChain::test_conditional_execution tests/test_simple.py::TestQuickCommands::test_true_false_commands

------
https://chatgpt.com/codex/tasks/task_e_68d168e0c6e08321aa4641c0ae7fbe9b