### PR TITLE
Include completed sessions in default session listing

### DIFF
--- a/src/claudecontrol/core.py
+++ b/src/claudecontrol/core.py
@@ -758,12 +758,13 @@ def get_session(session_id: str) -> Optional[Session]:
         return _sessions.get(session_id)
 
 
-def list_sessions(active_only: bool = True) -> List[Dict[str, Any]]:
+def list_sessions(active_only: bool = False) -> List[Dict[str, Any]]:
     """
     List all sessions
-    
+
     Args:
-        active_only: If True, only return alive sessions
+        active_only: If True, only return alive sessions. Defaults to False so
+            completed sessions remain visible until cleanup.
         
     Returns:
         List of session info dicts


### PR DESCRIPTION
## Summary
- default the `list_sessions` helper to include completed sessions so they stay visible until cleanup
- add regression coverage confirming completed sessions appear in listings by default and are filtered when `active_only=True`

## Testing
- `pytest tests/test_core.py::TestCleanup::test_completed_session_visible_until_cleanup`


------
https://chatgpt.com/codex/tasks/task_e_68d16db835308321804d0876fbc24274