### PR TITLE
Default InvestigationReport start time

### DIFF
--- a/src/claudecontrol/investigate.py
+++ b/src/claudecontrol/investigate.py
@@ -46,7 +46,7 @@ class ProgramState:
 class InvestigationReport:
     """Complete investigation findings"""
     program: str
-    started_at: datetime
+    started_at: datetime = field(default_factory=datetime.now)
     completed_at: Optional[datetime] = None
     entry_state: Optional[ProgramState] = None
     states: Dict[str, ProgramState] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- default `InvestigationReport.started_at` to `datetime.now()` via `dataclass` `default_factory` so reports can be created without an explicit timestamp

## Testing
- `pytest tests/test_investigate.py::TestInvestigationReport -q`
- `pytest` *(fails: multiple existing session-related tests time out or assert on unrelated behavior)*

------
https://chatgpt.com/codex/tasks/task_e_68d17049bc2083218b3b1f6936a0adca