### PR TITLE
Fix prompt detection to return matched prompt text

### DIFF
--- a/src/claudecontrol/investigate.py
+++ b/src/claudecontrol/investigate.py
@@ -282,8 +282,17 @@ class ProgramInvestigator:
         # Check common prompts first
         for prompt_type, patterns in COMMON_PROMPTS.items():
             for pattern in patterns:
-                if re.search(pattern, output):
-                    return pattern
+                last_valid_match = None
+                for match in re.finditer(pattern, output):
+                    start = match.start()
+                    if start == 0 or output[start - 1] in "\n\r":
+                        last_valid_match = match
+
+                if last_valid_match:
+                    matched_text = last_valid_match.group(0)
+                    if matched_text:
+                        stripped = matched_text.strip()
+                        return stripped or matched_text
         
         # Look for patterns at end of output
         lines = output.strip().split('\n')


### PR DESCRIPTION
## Summary
- update `_detect_prompt` to capture the matched prompt text from output instead of returning the regex pattern
- ensure we only keep prompt matches that begin a line so fallbacks can return full prompts when needed

## Testing
- pytest tests/test_investigate.py::TestProgramInvestigator::test_detect_prompt

------
https://chatgpt.com/codex/tasks/task_e_68d173afbd848321823b94b4748e816b