### PR TITLE
Validate black box tester program input

### DIFF
--- a/src/claudecontrol/testing.py
+++ b/src/claudecontrol/testing.py
@@ -31,11 +31,14 @@ class BlackBoxTester:
     def __init__(self, program: str, timeout: int = 10):
         """
         Initialize black box tester
-        
+
         Args:
             program: Program to test
             timeout: Default timeout for operations
         """
+        if not program or not str(program).strip():
+            raise ValueError("program must be a non-empty string")
+
         self.program = program
         self.timeout = timeout
         self.test_results = []
@@ -415,6 +418,9 @@ def black_box_test(
     Returns:
         Test results dictionary
     """
+    if not program or not str(program).strip():
+        raise ValueError("program must be a non-empty string")
+
     tester = BlackBoxTester(program, timeout=timeout)
     tester.run_all_tests()
     

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -193,21 +193,26 @@ class TestBlackBoxTestFunction:
         # Patch home directory
         def mock_home():
             return temp_dir
-        
+
         monkeypatch.setattr(Path, "home", mock_home)
-        
+
         results = black_box_test(
             "echo 'test'",
             timeout=2,
             save_report=True
         )
-        
+
         assert "report_path" in results
         assert results["report_path"] is not None
-        
+
         # Check file was created
         report_path = Path(results["report_path"])
         assert report_path.exists()
+
+    def test_black_box_test_empty_program(self):
+        """black_box_test should validate program input"""
+        with pytest.raises(ValueError):
+            black_box_test("   ")
 
 
 class TestSpecificScenarios:
@@ -263,9 +268,8 @@ class TestEdgeCases:
     
     def test_empty_program(self):
         """Test with empty program string"""
-        with pytest.raises(Exception):
-            tester = BlackBoxTester("", timeout=2)
-            tester.test_startup()
+        with pytest.raises(ValueError):
+            BlackBoxTester("", timeout=2)
     
     def test_very_short_timeout(self):
         """Test with very short timeout"""


### PR DESCRIPTION
## Summary
- raise a ValueError when the black box tester is constructed with an empty program
- guard the high-level helper with the same validation
- add unit tests that assert the new validation behavior

## Testing
- pytest tests/test_testing.py::TestEdgeCases::test_empty_program tests/test_testing.py::TestBlackBoxTestFunction::test_black_box_test_empty_program

------
https://chatgpt.com/codex/tasks/task_e_68d17550ec4883219eafd82ae04a6432