### PR TITLE
Add replay tape diff, matcher controls, and summary defaults

### DIFF
--- a/src/claudecontrol/core.py
+++ b/src/claudecontrol/core.py
@@ -98,10 +98,13 @@ class Session:
         tapes_path: Optional[str] = None,
         record: RecordMode = RecordMode.DISABLED,
         fallback: FallbackMode = FallbackMode.NOT_FOUND,
-        summary: bool = False,
+        summary: bool = True,
+        name: Optional[str] = None,
         tape_name_generator: Optional[TapeNameGenerator] = None,
         allow_env: Optional[List[str]] = None,
         ignore_env: Optional[List[str]] = None,
+        ignore_args: Optional[List[Union[int, str]]] = None,
+        ignore_stdin: bool = False,
         stdin_matcher: Optional[Callable] = None,
         command_matcher: Optional[Callable] = None,
         input_decorator: Optional[InputDecorator] = None,
@@ -123,6 +126,7 @@ class Session:
         self.latency = latency
         self.error_rate = error_rate
         self.summary = summary
+        self.name = name
         self._record_mode = record
         self._fallback_mode = fallback
         self._replay_enabled = replay
@@ -132,6 +136,8 @@ class Session:
         self._tape_index: Dict = {}
         self._allow_env = allow_env
         self._ignore_env = ignore_env
+        self._ignore_args = ignore_args
+        self._ignore_stdin = ignore_stdin
         self._stdin_matcher = stdin_matcher or default_stdin_matcher
         self._command_matcher = command_matcher or default_command_matcher
         self._key_builder = KeyBuilder(
@@ -139,6 +145,8 @@ class Session:
             self._ignore_env,
             self._stdin_matcher,
             self._command_matcher,
+            self._ignore_args,
+            self._ignore_stdin,
         )
         self._input_decorator = input_decorator
         self._output_decorator = output_decorator
@@ -247,7 +255,6 @@ class Session:
         self._tape_index = self._tape_store.build_index(self._key_builder)
         self.process = ReplayTransport(
             self._tape_store,
-            self._tape_index,
             self._key_builder,
             self._matching_context(),
             self.latency,

--- a/src/claudecontrol/replay/record.py
+++ b/src/claudecontrol/replay/record.py
@@ -103,7 +103,7 @@ class Recorder:
         self._builder = self.session._key_builder
         # Prime the store for lookups so record modes can act deterministically.
         self._store.load_all()
-        self._index: Dict[Tuple, Tuple[int, int]] = self._store.build_index(self._builder)
+        self._index: Dict[Tuple, List[Tuple[int, int]]] = self._store.build_index(self._builder)
 
     # ------------------------------------------------------------------ setup
     def start(self) -> None:
@@ -210,13 +210,13 @@ class Recorder:
         for ctx, exchange in self._pending:
             stdin = _input_to_bytes(exchange.input)
             key = self._builder.context_key(ctx, stdin)
-            match = self._index.get(key)
-            if match is None:
+            matches = self._index.get(key)
+            if not matches:
                 new_exchanges.append((ctx, exchange))
                 continue
             if self.mode == RecordMode.NEW:
                 continue
-            tape_idx, exchange_idx = match
+            tape_idx, exchange_idx = matches[0]
             replacements.setdefault(tape_idx, []).append((exchange_idx, exchange))
 
         for tape_idx, pairs in replacements.items():


### PR DESCRIPTION
## Summary
- expose new session options for replay matching and enable summaries by default to align with requirements
- enhance the replay tape store/index to respect ignore rules and provide fallback matching plus a CLI tape diff utility
- extend playback transport and recorder to use the richer index behaviour and add targeted tests for the new matching logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4a14d814c83219d4387e246a85bc7