### PR TITLE
Fix Mermaid comment syntax in data flow diagram

### DIFF
--- a/data_flow.md
+++ b/data_flow.md
@@ -95,7 +95,7 @@ graph TD
     ROUTER -->|probe cmd| PROBE
     ROUTER -->|chain cmd| CHAIN
     
-    %invaded Discovery Flow
+    %%invaded Discovery Flow
     INVESTIGATE -->|spawn| SPAWN
     PROBE -->|spawn| SPAWN
     STATE_MAP -->|spawn| SPAWN


### PR DESCRIPTION
## Summary
- correct the Mermaid diagram comment marker in `data_flow.md` to use the proper double-percent syntax

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4bd17cf548321a7517c1579abb392