### PR TITLE
Fix mermaid note participants in sequence diagram

### DIFF
--- a/sequence_diagrams.md
+++ b/sequence_diagrams.md
@@ -36,7 +36,7 @@ sequenceDiagram
 
     Session-->>Caller: ready session (send/expect/close)
 
-    Note over Session,Recorder,Player: Recorder & Player share MatchingContext, decorators, redactors
+    Note over Session,Recorder: Recorder & Player share MatchingContext, decorators, redactors
 ```
 
 ### Integration Notes


### PR DESCRIPTION
## Summary
- adjust the sequence diagram note to reference a supported participant list so Mermaid renders correctly

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68d4bd52ae5083219eb815e77e23a6bd