### PR TITLE
Fix mermaid sequence syntax

### DIFF
--- a/sequence_diagrams.md
+++ b/sequence_diagrams.md
@@ -116,7 +116,6 @@ sequenceDiagram
     Session->>Player: sendline("select 1;")
     Player->>Matcher: build_context(program, args, env, prompt, stdin)
     Matcher->>Store: lookup(context)
-
     alt Match found
         Store-->>Matcher: tape_ref
         Matcher-->>Player: matched_exchange


### PR DESCRIPTION
## Summary
- remove the blank line in the tape playback sequence diagram so Mermaid can parse the `Player->>Matcher` message block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4be798cc08321978590ab3cbfd66f