### PR TITLE
Fix Mermaid syntax for automation data flow

### DIFF
--- a/data_flow.md
+++ b/data_flow.md
@@ -253,7 +253,7 @@ graph LR
         ERROR[/Raise Exception/]
     end
 
-    CMD -->|control()| GET_SESSION
+    CMD -->|"control()"| GET_SESSION
     GET_SESSION -->|session| SEND
     SEND -->|text to stdin| EXPECT
     EXPECT --> MATCH


### PR DESCRIPTION
## Summary
- escape the control() edge label in the automation pipeline Mermaid diagram to satisfy GitHub's parser

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4be4c4f4c83219f51a726e00ecc15