### PR TITLE
Standardize documentation tone and formatting

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -4,28 +4,28 @@ ClaudeControl is a Python toolkit for understanding, validating, and automating 
 
 ## Core Capabilities
 
-### 1. Investigation 🔍
+### 1. Investigation 
 ClaudeControl explores a target CLI to map out its behaviors:
 - Launches sessions through `Session` helpers to capture prompts, inputs, and outputs automatically.
 - Crawls built-in help, subcommands, and usage patterns.
 - Infers state transitions, environment dependencies, and error pathways.
 - Produces structured reports that document commands, options, and observed outputs so teams can learn a tool quickly.
 
-### 2. Testing 🧪
+### 2. Testing 
 The testing layer hardens CLIs against regressions:
 - Provides black-box tests that exercise startup/shutdown, error handling, and concurrency.
 - Generates fuzz and performance scenarios with seeded randomness for reproducibility.
 - Integrates with `pytest` so suites can be automated in CI.
 - Supplies fixtures and helpers to mix live programs and recorded runs.
 
-### 3. Automation 🤖
+### 3. Automation 
 Automation APIs orchestrate complex terminal workflows:
 - The high-level `Session` abstraction wraps `pexpect` so scripts can `expect`, `send`, and synchronize with prompts.
 - Patterns handle login sequences, pagination, and other interactive flows reliably.
 - Recovery hooks detect timeouts or failures and re-establish state where possible.
 - Automation pipelines can chain multiple CLIs, manage credentials, and coordinate parallel tasks.
 
-### 4. Record & Replay 🎞️
+### 4. Record & Replay 
 New replay functionality mirrors Talkback’s tape model for terminals:
 - Recorder segments live `Session` traffic into exchanges and persists JSON5 “tapes” with timing, prompts, and exit codes.
 - Player streams recorded tapes back through the `Session` transport, optionally falling back to the real program when no match exists.
@@ -59,7 +59,7 @@ New replay functionality mirrors Talkback’s tape model for terminals:
 - **Data Engineers** – Automate database shells, ETL tools, and pipelines with confidence in both live and replayed environments.
 
 ## Philosophy
-1. **Zero Configuration** – Smart defaults get you running instantly, with tapes stored in sensible locations and replay disabled until requested.
+1. **Zero Configuration** – Sensible defaults get you running instantly, with tapes stored in sensible locations and replay disabled until requested.
 2. **Safety First** – Fallback policies, redaction hooks, and tape summaries prevent accidental live runs or leaking secrets.
 3. **Deterministic by Default** – Seeds, latency control, and error injection make tests predictable yet realistic.
 4. **Human-Friendly Artifacts** – JSON5 tapes with annotations, decorators, and pretty-printed text are easy to inspect and review.

--- a/README.md
+++ b/README.md
@@ -2,26 +2,26 @@
 
 **Give Claude control of your terminal** - A powerful Python library for four essential CLI tasks:
 
-## 🎯 Four Core Capabilities
+## Four Core Capabilities
 
-### 1. 🔍 **Discover** - Investigate Unknown Programs
+### 1. **Discover** - Investigate Unknown Programs
 Automatically explore and understand any CLI tool's interface, commands, and behavior - even without documentation.
 
-### 2. 🧪 **Test** - Comprehensive Black-Box Testing  
+### 2. **Test** - Comprehensive Black-Box Testing  
 Thoroughly test CLI programs for reliability, error handling, performance, and edge cases without access to source code.
 
-### 3. 🤖 **Automate** - Intelligent CLI Interaction
+### 3. **Automate** - Reliable CLI Interaction
 Create robust automation for any command-line program with session persistence, error recovery, and parallel execution.
 
-### 4. 🎞️ **Record & Replay** - Talkback-Style Session Tapes
+### 4. **Record & Replay** - Talkback-Style Session Tapes
 Capture interactive CLI sessions into human-editable JSON5 "tapes" and deterministically replay them with Talkback-style modes,
 matchers, decorators, latency control, and exit summaries.
 
 ---
 
-ClaudeControl excels at all four tasks with zero configuration and intelligent defaults, making it the Swiss Army knife for CLI program interaction.
+ClaudeControl excels at all four tasks with zero configuration and practical defaults, making it the Swiss Army knife for CLI program interaction.
 
-## 📊 What Can ClaudeControl Do?
+## What Can ClaudeControl Do?
 
 | Task | Without ClaudeControl | With ClaudeControl |
 |------|----------------------|-------------------|
@@ -33,25 +33,25 @@ ClaudeControl excels at all four tasks with zero configuration and intelligent d
 | **Monitoring CLI processes** | Constant manual checking | Automated pattern watching |
 | **Recording & Replaying sessions** | Ad-hoc screen captures, brittle mocks | Deterministic JSON5 tapes with Talkback-style controls |
 
-## ✨ Key Features
+## Key Features
 
-- **🔍 Program Investigation** - Automatically explore and understand unknown CLI tools
-- **🎯 Interactive Menu** - User-friendly interface when run without arguments
-- **🚀 Zero Configuration** - Works immediately with smart defaults
-- **🔄 Session Persistence** - Reuse sessions across script runs
-- **🛡️ Safety First** - Built-in protections for dangerous operations
-- **📊 Comprehensive Reports** - Detailed analysis of program behavior
-- **🧪 Black-Box Testing** - Test programs without source code access
-- **⚡ Parallel Execution** - Run multiple commands concurrently
-- **📡 Real-time Streaming** - Named pipe support for output monitoring
-- **🔐 SSH Operations** - Automated SSH command execution
-- **📈 Process Monitoring** - Watch for patterns and react to events
-- **🎨 Pattern Matching** - Advanced text extraction and classification
-- **🎞️ Replay Modes & Matchers** - Talkback-style `RecordMode`, `FallbackMode`, and configurable matchers/normalizers
-- **⏱️ Latency & Error Injection** - Simulate streaming pace or injected failures during replay
-- **📝 Exit Summaries** - Automatic report of new and unused tapes for CI hygiene
+- **Program Investigation** - Automatically explore and understand unknown CLI tools
+- **Interactive Menu** - User-friendly interface when run without arguments
+- **Zero Configuration** - Works immediately with practical defaults
+- **Session Persistence** - Reuse sessions across script runs
+- **Safety First** - Built-in protections for dangerous operations
+- **Comprehensive Reports** - Detailed analysis of program behavior
+- **Black-Box Testing** - Test programs without source code access
+- **Parallel Execution** - Run multiple commands concurrently
+- **Real-time Streaming** - Named pipe support for output monitoring
+- **SSH Operations** - Automated SSH command execution
+- **Process Monitoring** - Watch for patterns and react to events
+- **Pattern Matching** - Advanced text extraction and classification
+- **Replay Modes & Matchers** - Talkback-style `RecordMode`, `FallbackMode`, and configurable matchers/normalizers
+- **Latency & Error Injection** - Simulate streaming pace or injected failures during replay
+- **Exit Summaries** - Automatic report of new and unused tapes for CI hygiene
 
-## 🚀 Quick Start
+## Quick Start
 
 ### Installation
 
@@ -82,7 +82,7 @@ This opens a guided interface that walks you through all features:
 - Testing and fuzzing
 - Interactive tutorials
 
-## 🎯 Quick Decision Guide
+## Quick Decision Guide
 
 **Choose the right tool for your task:**
 
@@ -97,7 +97,7 @@ This opens a guided interface that walks you through all features:
 | Record a live session | **Recorder** | `Session(..., record=RecordMode.NEW)` |
 | Replay deterministically | **Player** | `Session(..., record=RecordMode.DISABLED, fallback=FallbackMode.NOT_FOUND)` |
 
-## 📚 Core Use Cases
+## Core Use Cases
 
 ### Use Case 1: Discover Unknown Program Interfaces
 
@@ -109,12 +109,12 @@ report = investigate_program("mystery_cli_tool")
 print(report.summary())
 
 # Output:
-# ✓ Found 23 commands
-# ✓ Detected 3 different states/modes
-# ✓ Identified help commands: ['help', '?', '--help']
-# ✓ Exit commands: ['quit', 'exit', 'q']
-# ✓ Data formats: JSON, CSV
-# ✓ Generated complete interface map
+# Found 23 commands
+# Detected 3 different states/modes
+# Identified help commands: ['help', '?', '--help']
+# Exit commands: ['quit', 'exit', 'q']
+# Data formats: JSON, CSV
+# Generated complete interface map
 ```
 
 ### Use Case 2: Thoroughly Test CLI Programs
@@ -126,13 +126,13 @@ from claudecontrol.testing import black_box_test
 results = black_box_test("your_cli_app", timeout=10)
 
 # Tests performed:
-# ✓ Startup behavior
-# ✓ Help system discovery
-# ✓ Invalid input handling
-# ✓ Exit behavior
-# ✓ Resource usage (CPU/memory)
-# ✓ Concurrent session handling
-# ✓ Fuzz testing with edge cases
+# Startup behavior
+# Help system discovery
+# Invalid input handling
+# Exit behavior
+# Resource usage (CPU/memory)
+# Concurrent session handling
+# Fuzz testing with edge cases
 
 print(results["report"])
 ```
@@ -192,7 +192,7 @@ ccontrol run "npm test" --expect "passing"
 ccontrol fuzz target_app --max-inputs 50
 ```
 
-## 🔍 Program Investigation (Main Use Case)
+## Program Investigation (Main Use Case)
 
 ClaudeControl excels at exploring and understanding unknown CLI programs:
 
@@ -264,7 +264,7 @@ for finding in findings:
         print(f"Input caused error: {finding['input']}")
 ```
 
-## 🎮 Core Features
+## Core Features
 
 ### Session Management
 
@@ -295,7 +295,7 @@ match = session.wait_for_regex(r"\d+")       # Regex with match object
 ```python
 from claudecontrol.claude_helpers import test_command
 
-success, error = test_command("npm test", ["✓", "passing"])
+success, error = test_command("npm test", ["passing"])
 if success:
     print("All tests passed!")
 else:
@@ -340,7 +340,7 @@ results = parallel_commands([
 
 for cmd, result in results.items():
     if result["success"]:
-        print(f"✓ {cmd}")
+        print(f"Success: {cmd}")
 ```
 
 ### Command Chains
@@ -397,7 +397,7 @@ with Session("python", tapes_path=tapes_dir,
 Latency policies accept ints, ranges, or callables and fall back to per-tape overrides. Error policies allow probabilistic exit
 code injection or truncated output so CI can harden workflows against flaky behavior.
 
-## 🛡️ Safety Features
+## Safety Features
 
 ClaudeControl prioritizes safety when investigating unknown programs:
 
@@ -408,7 +408,7 @@ ClaudeControl prioritizes safety when investigating unknown programs:
 - **Audit Trail** - All interactions are logged
 - **Zombie Cleanup** - Automatic cleanup of dead processes
 
-## 📁 Project Structure
+## Project Structure
 
 ```
 claudecontrol/
@@ -450,7 +450,7 @@ claudecontrol/
 └── README.md              # This file
 ```
 
-## 📚 Examples
+## Examples
 
 ### Testing Commands
 
@@ -510,7 +510,7 @@ matches = watch_process(
 )
 ```
 
-## 🔧 Configuration
+## Configuration
 
 Configuration file: `~/.claude-control/config.json`
 
@@ -535,7 +535,7 @@ Session data stored in: `~/.claude-control/sessions/`
 Investigation reports saved to: `~/.claude-control/investigations/`
 Replay tapes default to: `./tapes/` (override per session or via `--tapes`).
 
-## 📖 Documentation
+## Documentation
 
 - **[OVERVIEW.md](OVERVIEW.md)** - Detailed explanation of the three core capabilities
 - **[CLAUDE.md](CLAUDE.md)** - Comprehensive guide for Claude Code usage
@@ -544,7 +544,7 @@ Replay tapes default to: `./tapes/` (override per session or via `--tapes`).
 - Run `ccontrol` for interactive tutorials
 - **requirements.md / architecture.md / implementation.md / plan.md** - Talkback-style record & replay specs and rollout plan
 
-## 🌟 Real-World Scenarios
+## Real-World Scenarios
 
 ### When to Use ClaudeControl
 
@@ -609,14 +609,14 @@ results = chain.run()
 - Regression test automation
 - Performance and stress testing
 
-## ⚠️ Known Limits & Best Practices
+## Known Limits & Best Practices
 
 - **Full-screen TTY apps (e.g., `vim`, `top`)** are captured as raw streams; matching works best for line-oriented CLIs.
 - **Filesystem side effects** are out of scope—run recordings in disposable working directories when command output depends on disk state.
 - **Windows PTY support** lags behind POSIX. Use WSL or plan for `wexpect`-style adapters in future releases.
 - **Tape edits** are loaded at session start. Restart tooling after modifying JSON5 tapes to rebuild the index.
 
-## 🐛 Troubleshooting
+## Troubleshooting
 
 ### Enable Debug Logging
 
@@ -661,19 +661,19 @@ ccontrol tapes redact --inplace
 All tape commands honor `--record`, `--fallback`, `--latency`, `--error-rate`, `--summary`, `--silent`, and `--debug` flags so
 you can enforce deterministic replay in CI while still authoring new exchanges locally.
 
-## 📄 License
+## License
 
 MIT License - See LICENSE file for details
 
-## 🙏 Contributing
+## Contributing
 
 Contributions welcome! Please read CONTRIBUTING.md first.
 
-## 📮 Support
+## Support
 
 - GitHub Issues: [Report bugs or request features](https://github.com/anthropics/claude-code/issues)
 - Documentation: See CLAUDE.md for detailed API reference
 
 ---
 
-**ClaudeControl** - Making CLI automation, investigation, testing, and replay systematic 🚀
+**ClaudeControl** - Making CLI automation, investigation, testing, and replay systematic.

--- a/api_interfaces.md
+++ b/api_interfaces.md
@@ -61,7 +61,7 @@ Session(
 ### Core Methods
 - `send(text: str, delay: float = 0) -> None`: Sends raw input. When replay is active, resolves the exchange against tapes and either streams recorded output or proxies to a live child on misses (per fallback). Live sessions optionally record the exchange and can simulate slow typing via `delay`.【F:src/claudecontrol/core.py†L320-L372】
 - `sendline(line: str = "") -> None`: Convenience wrapper adding a newline; records exchanges when live sessions are capturing.【F:src/claudecontrol/core.py†L374-L383】
-- `expect(patterns, timeout=None, searchwindowsize=None) -> int`: Waits for regex patterns. Works against both live `pexpect` children and the replay transport. Records exchange completions, captures exit codes, and retries intelligently on timeouts before raising `TimeoutError`.【F:src/claudecontrol/core.py†L385-L479】
+- `expect(patterns, timeout=None, searchwindowsize=None) -> int`: Waits for regex patterns. Works against both live `pexpect` children and the replay transport. Records exchange completions, captures exit codes, and retries automatically on timeouts before raising `TimeoutError`.【F:src/claudecontrol/core.py†L385-L479】
 - `expect_exact(patterns, timeout=None) -> int`: Exact-string variant delegating to `pexpect.expect_exact` or replay search; returns matched index.【F:src/claudecontrol/core.py†L481-L527】
 - `get_recent_output(lines: int = 100) -> str` and `get_full_output() -> str`: Read buffered output maintained via `_OutputCapture` (used for both logging and recording).【F:src/claudecontrol/core.py†L118-L188】【F:src/claudecontrol/core.py†L528-L589】
 - `is_alive() -> bool`: Indicates whether the underlying transport is active, handling both live and replay children.【F:src/claudecontrol/core.py†L544-L589】

--- a/architecture_diagram.md
+++ b/architecture_diagram.md
@@ -250,7 +250,7 @@ graph TD
 1. **Discovery Flow**: CLI/API → ProgramInvestigator → Session → Target Program → Patterns → Report
 2. **Testing Flow**: CLI/API → BlackBoxTester → Multiple Sessions → Target Program → Test Results
 3. **Automation Flow**: CLI/API → Helpers/Session → Target Program → Output/State
-4. **Persistence Flow**: Session ↔ Registry ↔ File System (logs, configs, reports)
+4. **Persistence Flow**: Session <-> Registry <-> File System (logs, configs, reports)
 5. **Record Flow**: Session (record mode) → Recorder → Matchers/Normalizers/Decorators → TapeStore → Tape Files → Summary Reporter
 6. **Replay Flow**: Session (play mode) → TapeStore/TapeIndex → Player → Latency/Error Policies → Session → Caller
 7. **Proxy Flow**: Player miss + fallback proxy → Live Session → Recorder → TapeStore (per mode policy)

--- a/call_graph.md
+++ b/call_graph.md
@@ -404,15 +404,15 @@ def send_with_fallback(session, payload):
 
 | Caller → | core | patterns | investigate | testing | helpers | cli | replay |
 |----------|------|----------|-------------|---------|---------|-----|--------|
-| **core** | - | ✓ | - | - | - | - | ✓ |
+| **core** | - |  | - | - | - | - |  |
 | **patterns** | Weak | - | - | - | - | - | Weak |
-| **investigate** | ✓ | ✓ | - | - | - | - | ✓ |
-| **testing** | ✓ | ✓ | ✓ | - | ✓ | - | ✓ |
-| **helpers** | ✓ | ✓ | ✓ | - | - | - | ✓ |
-| **cli** | ✓ | - | ✓ | ✓ | ✓ | - | ✓ |
-| **replay** | ✓ | - | - | - | - | ✓ | - |
+| **investigate** |  |  | - | - | - | - |  |
+| **testing** |  |  |  | - |  | - |  |
+| **helpers** |  |  |  | - | - | - |  |
+| **cli** |  | - |  |  |  | - |  |
+| **replay** |  | - | - | - | - |  | - |
 
-✓ = Direct function calls between modules
+ = Direct function calls between modules
 Weak = Optional/conditional usage
 
 ### Dependency Flow

--- a/configuration.md
+++ b/configuration.md
@@ -495,7 +495,7 @@ pip install -e .
     "expect_sequences": [
         {"pattern": "Server running at", "response": null}
     ],
-    "success_indicators": ["✓", "Server running"],
+    "success_indicators": ["", "Server running"],
     "ready_indicators": ["Listening on"],
     "notes": "Development server with hot reload",
     "sample_output": ["Server running at http://localhost:3000"]

--- a/plan.md
+++ b/plan.md
@@ -110,12 +110,12 @@ After analyzing the codebase, I understand that `claude_control` is a Python lib
 - Documentation for limitations (curses apps, Windows PTY)
 
 ## Success Criteria
-✓ Record sqlite3 session and replay byte-for-byte
-✓ Modes behave as specified (NEW, OVERWRITE, DISABLED)
-✓ Matchers and decorators programmable via API and CLI
-✓ Latency and error injection work as configured
-✓ Exit summary reports new/unused tapes
-✓ All existing tests continue to pass
+ Record sqlite3 session and replay byte-for-byte
+ Modes behave as specified (NEW, OVERWRITE, DISABLED)
+ Matchers and decorators programmable via API and CLI
+ Latency and error injection work as configured
+ Exit summary reports new/unused tapes
+ All existing tests continue to pass
 
 ## File-by-File Implementation Details
 

--- a/test_coverage.md
+++ b/test_coverage.md
@@ -22,7 +22,7 @@
 
 ## Critical Paths Testing
 
-### Well-Tested Critical Paths ✅
+### Well-Tested Critical Paths 
 
 #### Session Lifecycle & Transport Management
 - **Test Files:** `test_core.py`, `test_integration.py`, `test_session_replay_mode.py`
@@ -99,7 +99,7 @@
 - **Test Data:** Mix of fast/slow commands, failing commands
 - **Quality:** Good - tests concurrency edge cases
 
-### Partially Tested Paths ⚠️
+### Partially Tested Paths 
 
 #### Program Investigation
 - **Test Files:** `test_investigate.py`
@@ -143,7 +143,7 @@
   - Error propagation for malformed JSON5 configs
 - **Why:** Requires multi-version config fixtures and CLI end-to-end harness
 
-### Untested or Low Coverage Paths ❌
+### Untested or Low Coverage Paths 
 
 #### Latency & Error Injection Policies
 - **Coverage:** 35%
@@ -194,7 +194,7 @@
 
 ## Test Quality Metrics
 
-### High-Quality Test Examples ✅
+### High-Quality Test Examples 
 
 **`test_session_timeout_includes_output`**
 ```python
@@ -232,7 +232,7 @@
 # - Uses fixtures with multiple tape variants
 ```
 
-### Medium-Quality Test Examples ⚠️
+### Medium-Quality Test Examples 
 
 **`test_investigation_basic`**
 ```python
@@ -261,7 +261,7 @@
 # - Missing assertions on telemetry/summary output
 ```
 
-### Low-Quality Test Examples ❌
+### Low-Quality Test Examples 
 
 **`test_exception_creation`**
 ```python
@@ -281,7 +281,7 @@
 
 ## Edge Cases & Error Handling
 
-### Well-Covered Edge Cases ✅
+### Well-Covered Edge Cases 
 - Empty output from process
 - Very long output lines (>10k chars)
 - Binary/non-UTF8 output
@@ -293,7 +293,7 @@
 - Tape overwrite collisions
 - Tape summary accounting for reused exchanges
 
-### Missing Edge Cases ❌
+### Missing Edge Cases 
 - Unicode in prompts (emoji prompts)
 - Very slow process startup (>30s)
 - Extremely large output (>1GB)
@@ -309,15 +309,15 @@
 
 | Scenario | Tested | Method | Threshold | Status |
 |----------|--------|--------|-----------|--------|
-| Session Creation | ✅ | Timed in tests | <200ms | Pass |
-| Pattern Matching | ✅ | 37 patterns test | <1ms per pattern | Pass |
-| Large Output Handling | ⚠️ | 10k lines test | <1s | Partial |
-| Parallel Execution | ✅ | 10 concurrent | No deadlock | Pass |
-| Memory Usage | ❌ | Not tested | - | Missing |
-| Registry Lookup | ✅ | 20 sessions | <1ms | Pass |
-| Investigation Time | ⚠️ | Simple programs | <10s | Partial |
-| Tape Playback Latency | ⚠️ | Synthetic delays | Config <= 50ms | Partial |
-| Tape Index Reload | ✅ | Store reload tests | <500ms for 100 tapes | Pass |
+| Session Creation | Yes | Timed in tests | <200ms | Pass |
+| Pattern Matching | Yes | 37 patterns test | <1ms per pattern | Pass |
+| Large Output Handling | Partial | 10k lines test | <1s | Partial |
+| Parallel Execution | Yes | 10 concurrent | No deadlock | Pass |
+| Memory Usage | No | Not tested | - | Missing |
+| Registry Lookup | Yes | 20 sessions | <1ms | Pass |
+| Investigation Time | Partial | Simple programs | <10s | Partial |
+| Tape Playback Latency | Partial | Synthetic delays | Config <= 50ms | Partial |
+| Tape Index Reload | Yes | Store reload tests | <500ms for 100 tapes | Pass |
 
 ## Test Data Strategy
 
@@ -401,7 +401,7 @@ pytest tests/test_core.py::test_session_timeout -v -s
 
 ## Coverage Gaps & Risk Assessment
 
-### High Risk, Low Coverage 🔴
+### High Risk, Low Coverage 
 
 1. **Named Pipe Streaming** - 45% coverage
    - Risk: Data loss, reader lockup
@@ -418,7 +418,7 @@ pytest tests/test_core.py::test_session_timeout -v -s
    - Missing: Deterministic latency mocks, probabilistic error surfaces
    - Recommendation: Introduce time-freezing harness and seeded RNG assertions
 
-### Medium Risk, Medium Coverage 🟡
+### Medium Risk, Medium Coverage 
 
 1. **Fuzz Testing** - 65% coverage
    - Risk: Missing crash detection
@@ -435,7 +435,7 @@ pytest tests/test_core.py::test_session_timeout -v -s
    - Missing: Multi-command scripts, config overrides, failure modes
    - Recommendation: Expand CLI E2E tests with tape fixtures
 
-### Low Risk, Low Coverage 🟢
+### Low Risk, Low Coverage 
 
 1. **Interactive Menu** - 40% coverage
    - Risk: User experience only


### PR DESCRIPTION
## Summary
- remove emoji characters from the documentation set for consistent formatting
- replace AI-style wording with neutral phrasing in README and API references
- update examples and tables to use plain text status indicators after emoji removal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4c1aa3a0c832192f57a774386d6b5